### PR TITLE
Expand/Update build tools defaults.

### DIFF
--- a/.github/workflows/phpunit.yaml
+++ b/.github/workflows/phpunit.yaml
@@ -21,8 +21,8 @@ jobs:
       DB_PASSWORD: root
     strategy:
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
-        wp-versions: [ '6.2', '6.3', '6.4', 'latest', 'trunk' ]
+        php-versions: ['8.0', '8.1', '8.2', '8.3', '8.4']
+        wp-versions: [ '6.5', '6.6', '6.7', 'latest', 'trunk' ]
     name: WP ${{ matrix.wp-versions }} / PHP ${{ matrix.php-versions }}
 
     steps:

--- a/.github/workflows/wordpress-version-checker.yaml
+++ b/.github/workflows/wordpress-version-checker.yaml
@@ -1,0 +1,19 @@
+name: "WordPress version checker"
+on:
+  push:
+    branches:
+      - main
+  schedule:
+    - cron: '0 0 * * *'
+
+permissions:
+  issues: write
+
+jobs:
+  wordpress-version-checker:
+    runs-on: ubuntu-latest
+    steps:
+      - name: WordPress version checker
+        uses: skaut/wordpress-version-checker@9d247334f5b30202cb9c1f4aee74c52f37399f69 # 2.2.3
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.wordpress-version-checker.json
+++ b/.wordpress-version-checker.json
@@ -1,0 +1,5 @@
+{
+	"assignees": ["peterwilsoncc"],
+	"channel": "beta",
+	"readme": "readme.txt"
+}

--- a/inc/namespace.php
+++ b/inc/namespace.php
@@ -10,6 +10,8 @@
 
 namespace PWCC\WpPluginTemplate;
 
+const PLUGIN_VERSION = '1.0.0';
+
 /**
  * Bootstrap the plugin.
  */

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === WP Plugin Template ===
 Contributors: peterwilsoncc
 Tags:
-Tested up to: 6.5
+Tested up to: 6.8
 Stable tag: 1.0.0
 License: MIT
 License URI: https://github.com/peterwilsoncc/wp-plugin-template/blob/main/LICENSE

--- a/readme.txt
+++ b/readme.txt
@@ -1,10 +1,8 @@
 === WP Plugin Template ===
 Contributors: peterwilsoncc
 Tags:
-Requires at least: 6.2
 Tested up to: 6.5
 Stable tag: 1.0.0
-Requires PHP: 7.4
 License: MIT
 License URI: https://github.com/peterwilsoncc/wp-plugin-template/blob/main/LICENSE
 

--- a/tests/class-test-plugin-headers.php
+++ b/tests/class-test-plugin-headers.php
@@ -1,0 +1,314 @@
+<?php
+/**
+ * Test Plugin Readme and PHP Headers
+ *
+ * @package PWCC\WpPluginTemplate\Tests
+ */
+
+namespace PWCC\WpPluginTemplate\Tests;
+
+use WP_UnitTestCase;
+
+const OPTIONAL  = 0;
+const REQUIRED  = 1;
+const FORBIDDEN = 2;
+
+/**
+ * Test Plugin Readme and PHP Headers
+ */
+class Test_Plugin_Headers extends WP_UnitTestCase {
+
+	/**
+	 * Readme headers specification
+	 *
+	 * @var array<string,int> Headers defined in the readme spec. Key: Header; Value: OPTIONAL, REQUIRED, FORBIDDEN.
+	 */
+	public static $readme_headers = array(
+		'Contributors'      => REQUIRED,
+		'Tags'              => OPTIONAL,
+		'Donate link'       => OPTIONAL,
+		'Tested up to'      => REQUIRED,
+		'Stable tag'        => REQUIRED,
+		'License'           => REQUIRED,
+		'License URI'       => OPTIONAL,
+
+		// Plugin file headers that do not belong in the readme.
+		'Plugin Name'       => FORBIDDEN,
+		'Plugin URI'        => FORBIDDEN,
+		'Description'       => FORBIDDEN,
+		'Version'           => FORBIDDEN,
+		'Author'            => FORBIDDEN,
+		'Author URI'        => FORBIDDEN,
+		'Text Domain'       => FORBIDDEN,
+		'Domain Path'       => FORBIDDEN,
+		'Network'           => FORBIDDEN,
+		'Update URI'        => FORBIDDEN,
+		'Requires at least' => FORBIDDEN, // Both WP and the plugin directory prefer the version in the plugin file.
+		'Requires PHP'      => FORBIDDEN, // Both WP and the plugin directory prefer the version in the plugin file.
+		'Requires Plugins'  => FORBIDDEN,
+	);
+
+	/**
+	 * Plugin headers specification
+	 *
+	 * @var array<string,int> Headers defined in the plugin spec. Key: Header; Value: OPTIONAL, REQUIRED, FORBIDDEN.
+	 */
+	public static $plugin_headers = array(
+		'Plugin Name'       => REQUIRED,
+		'Plugin URI'        => OPTIONAL,
+		'Description'       => REQUIRED,
+		'Version'           => REQUIRED,
+		'Requires at least' => REQUIRED, // Not required by the spec but I'm enforcing it.
+		'Requires PHP'      => REQUIRED, // Not required by the spec but I'm enforcing it.
+		'Author'            => REQUIRED,
+		'Author URI'        => OPTIONAL,
+		'License'           => REQUIRED,
+		'License URI'       => OPTIONAL,
+		'Text Domain'       => OPTIONAL,
+		'Domain Path'       => OPTIONAL,
+		'Network'           => OPTIONAL,
+		'Update URI'        => OPTIONAL,
+		'Requires Plugins'  => OPTIONAL,
+
+		// Readme file headers that do not belong in the plugin file.
+		'Contributors'      => FORBIDDEN,
+		'Tags'              => FORBIDDEN,
+		'Donate link'       => FORBIDDEN,
+		'Stable tag'        => FORBIDDEN,
+
+		/*
+		 * Opinionated: Allowed by the spec.
+		 *
+		 * The WordPress plugin directory will use the plugin file headers if
+		 * it exists, and fall back to the readme file if it does not.
+		 *
+		 * However, the 10up Github Action for deploying updates to the
+		 * directory will require a version bump if the plugin file is
+		 * modified, so it's best to keep tested up to in the readme file.
+		 *
+		 * WordPress Core doesn't use the header, it pulls the data in
+		 * from the plugin API.
+		 */
+		'Tested up to'      => FORBIDDEN,
+	);
+
+	/**
+	 * Headers defined in the plugins readme.text file.
+	 *
+	 * @var string[] Headers defined in the readme spec Header => value.
+	 */
+	public static $defined_readme_headers = array();
+
+	/**
+	 * Headers defined in the plugin file.
+	 *
+	 * @var string[] Headers defined in the plugin spec Header => value.
+	 */
+	public static $defined_plugin_headers = array();
+
+	/**
+	 * Set up shared fixtures.
+	 */
+	public static function wpSetupBeforeClass() {
+		// Get the readme headers.
+		$readme_file_data = array();
+		foreach ( self::$readme_headers as $header => $required ) {
+			$readme_file_data[ $header ] = $header;
+		}
+		self::$defined_readme_headers = get_file_data(
+			__DIR__ . '/../readme.txt',
+			$readme_file_data
+		);
+		self::$defined_readme_headers = array_filter( self::$defined_readme_headers );
+
+		// Get the plugin headers.
+		// Plugin name.
+		$plugin_file_name = basename( dirname( __DIR__ ) ) . '.php';
+		if ( ! file_exists( __DIR__ . "/../{$plugin_file_name}" ) ) {
+			// Fallback to the generic plugin file name.
+			$plugin_file_name = 'plugin.php';
+		}
+
+		$plugin_file_data = array();
+		foreach ( self::$plugin_headers as $header => $required ) {
+			$plugin_file_data[ $header ] = $header;
+		}
+
+		self::$defined_plugin_headers = get_file_data(
+			__DIR__ . "/../{$plugin_file_name}",
+			$plugin_file_data
+		);
+		self::$defined_plugin_headers = array_filter( self::$defined_plugin_headers );
+	}
+
+	/**
+	 * Test that the readme file has all required headers.
+	 *
+	 * @dataProvider data_required_readme_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_required_readme_headers( $header ) {
+		$this->assertArrayHasKey( $header, self::$defined_readme_headers, "The readme file header '{$header}' is missing." );
+		$this->assertNotEmpty( self::$defined_readme_headers[ $header ], "The readme file header '{$header}' is empty." );
+	}
+
+	/**
+	 * Data provider for test_required_readme_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_required_readme_headers() {
+		$required_headers = array_filter(
+			self::$readme_headers,
+			function ( $status ) {
+				return REQUIRED === $status;
+			}
+		);
+		$headers          = array();
+		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the readme file does not have any forbidden headers.
+	 *
+	 * @dataProvider data_forbidden_readme_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_forbidden_readme_headers( $header ) {
+		$this->assertArrayNotHasKey( $header, self::$defined_readme_headers, "The readme file header '{$header}' is forbidden." );
+	}
+
+	/**
+	 * Data provider for test_forbidden_readme_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_forbidden_readme_headers() {
+		$forbidden_headers = array_filter(
+			self::$readme_headers,
+			function ( $status ) {
+				return FORBIDDEN === $status;
+			}
+		);
+		$headers           = array();
+		foreach ( $forbidden_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the plugin file has all required headers.
+	 *
+	 * @dataProvider data_required_plugin_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_required_plugin_headers( $header ) {
+		$this->assertArrayHasKey( $header, self::$defined_plugin_headers, "The plugin file header '{$header}' is missing." );
+		$this->assertNotEmpty( self::$defined_plugin_headers[ $header ], "The readme file header '{$header}' is empty." );
+	}
+
+	/**
+	 * Data provider for test_required_plugin_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_required_plugin_headers() {
+		$required_headers = array_filter(
+			self::$plugin_headers,
+			function ( $status ) {
+				return REQUIRED === $status;
+			}
+		);
+		$headers          = array();
+		foreach ( $required_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that the plugin file does not have any forbidden headers.
+	 *
+	 * @dataProvider data_forbidden_plugin_headers
+	 *
+	 * @param string $header Header to test.
+	 */
+	public function test_forbidden_plugin_headers( $header ) {
+		$this->assertArrayNotHasKey( $header, self::$defined_plugin_headers, "The plugin file header '{$header}' is forbidden." );
+	}
+
+	/**
+	 * Data provider for test_forbidden_plugin_headers.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_forbidden_plugin_headers() {
+		$forbidden_headers = array_filter(
+			self::$plugin_headers,
+			function ( $status ) {
+				return FORBIDDEN === $status;
+			}
+		);
+		$headers           = array();
+		foreach ( $forbidden_headers as $header => $required ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+
+	/**
+	 * Test that headers defined in both the readme and plugin file match.
+	 *
+	 * @dataProvider data_common_headers_match
+	 *
+	 * @param string      $plugin_header_name Plugin file header name to test.
+	 * @param string|null $readme_header_name Readme file header name to test. If null, the plugin header name will be used.
+	 */
+	public function test_common_headers_match( $plugin_header_name, $readme_header_name = null ) {
+		$readme_header_name = $readme_header_name ?? $plugin_header_name;
+		if ( empty( self::$defined_plugin_headers[ $plugin_header_name ] ) || empty( self::$defined_readme_headers[ $readme_header_name ] ) ) {
+			// The header is not common to both files so the test passes.
+			$this->assertTrue( true );
+			return;
+		}
+
+		$plugin_header = self::$defined_plugin_headers[ $plugin_header_name ];
+		$readme_header = self::$defined_readme_headers[ $readme_header_name ];
+
+		$message = "The header '{$plugin_header_name}' does not match between the readme and plugin file.";
+		if ( $plugin_header_name !== $readme_header_name ) {
+			$message = "The plugin header '{$plugin_header_name}' does not match the readme header '{$readme_header_name}'.";
+		}
+
+		$this->assertSame( $plugin_header, $readme_header, $message );
+	}
+
+	/**
+	 * Data provider for test_common_headers_match.
+	 *
+	 * @return array[] Data provider.
+	 */
+	public function data_common_headers_match() {
+		// Can't use the defined headers as they are not defined until after this is called.
+		$common_headers = array_intersect_key(
+			self::$readme_headers,
+			self::$plugin_headers
+		);
+
+		$headers = array();
+		// Always test the version matches the stable tag.
+		$headers['Stable tag matches version'] = array( 'Version', 'Stable tag' );
+
+		foreach ( $common_headers as $header => $value ) {
+			$headers[ $header ] = array( $header );
+		}
+		return $headers;
+	}
+}

--- a/tests/class-test-plugin-versions.php
+++ b/tests/class-test-plugin-versions.php
@@ -64,6 +64,7 @@ class Test_Plugin_Versions extends WP_UnitTestCase {
 			return;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- fine for the tests.
 		$package_data = json_decode( file_get_contents( $package_file ), true );
 		$this->assertSame( PLUGIN_VERSION, $package_data['version'], 'The version in package.json does not match the plugin version constant.' );
 	}
@@ -79,6 +80,7 @@ class Test_Plugin_Versions extends WP_UnitTestCase {
 			return;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- fine for the tests.
 		$package_lock_data = json_decode( file_get_contents( $package_lock_file ), true );
 		$this->assertSame( PLUGIN_VERSION, $package_lock_data['version'], 'The version in package-lock.json does not match the plugin version constant.' );
 		$this->assertSame( PLUGIN_VERSION, $package_lock_data['packages']['']['version'], "The packages['']['version'] in package-lock.json packages does not match the plugin version constant." );
@@ -103,6 +105,7 @@ class Test_Plugin_Versions extends WP_UnitTestCase {
 			return;
 		}
 
+		// phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents -- fine for the tests.
 		$composer_data = json_decode( file_get_contents( $composer_file ), true );
 		$this->assertArrayNotHasKey( 'version', $composer_data, 'The version key should not be present in composer.json.' );
 	}

--- a/tests/class-test-plugin-versions.php
+++ b/tests/class-test-plugin-versions.php
@@ -1,0 +1,109 @@
+<?php
+/**
+ * Test Plugin Versions match.
+ *
+ * @package PWCC\WpPluginTemplate\Tests
+ */
+
+namespace PWCC\WpPluginTemplate\Tests;
+
+use WP_UnitTestCase;
+
+use const PWCC\WpPluginTemplate\PLUGIN_VERSION;
+
+/**
+ * Test Plugin Readme and PHP Headers
+ */
+class Test_Plugin_Versions extends WP_UnitTestCase {
+
+	/**
+	 * Test Stable Tag in readme.txt matches plugin version.
+	 */
+	public function test_stable_tag_matches_plugin_version() {
+		$readme_file = __DIR__ . '/../readme.txt';
+		$readme_data = get_file_data(
+			$readme_file,
+			array(
+				'Stable tag' => 'Stable tag',
+			)
+		);
+
+		$this->assertSame( PLUGIN_VERSION, $readme_data['Stable tag'], 'The Stable tag in readme.txt does not match the plugin version.' );
+	}
+
+	/**
+	 * Test version header in the plugin file matches plugin version constant.
+	 */
+	public function test_plugin_version_header() {
+		// Get the plugin headers.
+		// Plugin name.
+		$plugin_file_name = basename( dirname( __DIR__ ) ) . '.php';
+		if ( ! file_exists( __DIR__ . "/../{$plugin_file_name}" ) ) {
+			// Fallback to the generic plugin file name.
+			$plugin_file_name = 'plugin.php';
+		}
+
+		$plugin_file_data = get_file_data(
+			__DIR__ . "/../{$plugin_file_name}",
+			array(
+				'Version' => 'Version',
+			)
+		);
+
+		$this->assertSame( PLUGIN_VERSION, $plugin_file_data['Version'], 'The Version header in the plugin file does not match the plugin version constant.' );
+	}
+
+	/**
+	 * Test the plugin version in package.json matches the plugin version constant.
+	 */
+	public function test_package_json_version() {
+		$package_file = __DIR__ . '/../package.json';
+		if ( ! file_exists( $package_file ) ) {
+			// Package file does not exist, consider this test passed.
+			$this->assertTrue( true );
+			return;
+		}
+
+		$package_data = json_decode( file_get_contents( $package_file ), true );
+		$this->assertSame( PLUGIN_VERSION, $package_data['version'], 'The version in package.json does not match the plugin version constant.' );
+	}
+
+	/**
+	 * Test the plugin version in package-lock.json matches the plugin version constant.
+	 */
+	public function test_package_lock_json_version() {
+		$package_lock_file = __DIR__ . '/../package-lock.json';
+		if ( ! file_exists( $package_lock_file ) ) {
+			// Package lock file does not exist, consider this test passed.
+			$this->assertTrue( true );
+			return;
+		}
+
+		$package_lock_data = json_decode( file_get_contents( $package_lock_file ), true );
+		$this->assertSame( PLUGIN_VERSION, $package_lock_data['version'], 'The version in package-lock.json does not match the plugin version constant.' );
+		$this->assertSame( PLUGIN_VERSION, $package_lock_data['packages']['']['version'], "The packages['']['version'] in package-lock.json packages does not match the plugin version constant." );
+	}
+
+	/**
+	 * Ensure that composer.json does not have a version key.
+	 *
+	 * Per the docs:
+	 *
+	 * > In most cases this is not required and should be omitted (see below).
+	 * >
+	 * > Packagist uses VCS repositories, so the statement above is very much true for Packagist
+	 * > as well. Specifying the version yourself will most likely end up creating problems at
+	 * > some point due to human error.
+	 */
+	public function test_composer_version_is_not_present() {
+		$composer_file = __DIR__ . '/../composer.json';
+		if ( ! file_exists( $composer_file ) ) {
+			// Composer file does not exist, consider this test passed.
+			$this->assertTrue( true );
+			return;
+		}
+
+		$composer_data = json_decode( file_get_contents( $composer_file ), true );
+		$this->assertArrayNotHasKey( 'version', $composer_data, 'The version key should not be present in composer.json.' );
+	}
+}

--- a/tests/class-test-sample.php
+++ b/tests/class-test-sample.php
@@ -19,11 +19,4 @@ class Test_Sample extends WP_UnitTestCase {
 	public function test_passing_test() {
 		$this->assertTrue( true );
 	}
-
-	/**
-	 * Test failing test.
-	 */
-	public function test_failing_test() {
-		$this->assertTrue( false );
-	}
 }

--- a/wp-plugin-template.php
+++ b/wp-plugin-template.php
@@ -9,7 +9,7 @@
  *
  * @wordpress-plugin
  * Plugin Name: WP Plugin Template
- * Description:
+ * Description:  A template for creating WordPress plugins.
  * Version: 1.0.0
  * Requires at least: 6.0
  * Requires PHP: 7.4

--- a/wp-plugin-template.php
+++ b/wp-plugin-template.php
@@ -11,8 +11,8 @@
  * Plugin Name: WP Plugin Template
  * Description:  A template for creating WordPress plugins.
  * Version: 1.0.0
- * Requires at least: 6.0
- * Requires PHP: 7.4
+ * Requires at least: 6.5
+ * Requires PHP: 8.0
  * Author: Peter Wilson
  * Author URI: https://peterwilson.cc
  * License: MIT


### PR DESCRIPTION
* Include plugin header tests by default
* Include version tests by default
* Bump minimum PHP versions tested and required
* Bump minimum WP versions tested and required
* Add WP Version check action
* Remove failing sample test.